### PR TITLE
Find chatops room by id instead of the topic.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-bot",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "Apache OSS Bot",
   "main": "index.js",
   "engines": {

--- a/src/chatops.ts
+++ b/src/chatops.ts
@@ -5,10 +5,8 @@ import {
 
 import {
   log,
+  CHATOPS_ROOM_ID,
 }                   from './config'
-
-// const CHATOPS_ROOM_TOPIC = 'OSS Bot ChatOps'
-const CHATOPS_ROOM_ID = '18995691396@chatroom'
 
 let room: Room
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,3 +14,5 @@ export const VERSION = pkg.version
  * Env Vars
  */
 export const PORT = process.env.PORT || 8788
+
+export const CHATOPS_ROOM_ID = '18995691396@chatroom'

--- a/src/handlers/on-message.ts
+++ b/src/handlers/on-message.ts
@@ -4,6 +4,10 @@ import {
   Wechaty,
 }             from 'wechaty'
 
+import {
+  CHATOPS_ROOM_ID,
+}                   from '../config'
+
 export default async function onMessage (
   this    : Wechaty,
   message : Message,
@@ -13,11 +17,12 @@ export default async function onMessage (
   if (!contact) {
     return
   }
-  if (text === 'oss') {
+  if (text.toLowerCase() === 'oss') {
 
     // To Be Fix: Change "OSS Bot ChatOps" Group Name to actual group name
     log.info('on-message', 'Begin to find the OSS Bot ChatOps room')
-    const room = await this.Room.find({ topic: 'OSS Bot ChatOps' })
+    const room = this.Room.load(CHATOPS_ROOM_ID)
+
     if (room) {
       await room.add(contact)
 

--- a/src/start-web.ts
+++ b/src/start-web.ts
@@ -24,6 +24,19 @@ async function chatopsHandler (request: Request, response: ResponseToolkit) {
   return response.redirect('/')
 }
 
+async function githubWebhookHandler (
+  request: Request,
+  response: ResponseToolkit,
+) {
+  log.info('startWeb', 'githubWebhookHandler()')
+
+  const payload = request.payload as any
+
+  console.log(payload)
+
+  return response.response()
+}
+
 export async function startWeb (bot: Wechaty): Promise<void> {
   log.verbose('startWeb', 'startWeb(%s)', bot)
 

--- a/src/start-web.ts
+++ b/src/start-web.ts
@@ -24,19 +24,6 @@ async function chatopsHandler (request: Request, response: ResponseToolkit) {
   return response.redirect('/')
 }
 
-async function githubWebhookHandler (
-  request: Request,
-  response: ResponseToolkit,
-) {
-  log.info('startWeb', 'githubWebhookHandler()')
-
-  const payload = request.payload as any
-
-  console.log(payload)
-
-  return response.response()
-}
-
 export async function startWeb (bot: Wechaty): Promise<void> {
   log.verbose('startWeb', 'startWeb(%s)', bot)
 


### PR DESCRIPTION
because the topic might be changed, but the room id will not.